### PR TITLE
Add fallback to reference 🐼.

### DIFF
--- a/src/poeditor/terms.test.ts
+++ b/src/poeditor/terms.test.ts
@@ -12,7 +12,7 @@ describe('The Poeditor Terms wrapper', () => {
     expect(await listProjectLanguageTerms(1234, 'de')).toEqual({
       'contracts.unit-type.caretaker-room': 'Hauswartraum',
       'contracts.unit-type.carport': 'Einstellplatz',
-      'test.missing.translation': '',
+      'test.missing.translation': 'Test Missing Translation (reference)',
     })
   })
 })

--- a/src/poeditor/terms.ts
+++ b/src/poeditor/terms.ts
@@ -16,13 +16,15 @@ export default async function listProjectLanguageTerms(
       (
         terms: any,
         {
+          reference,
           term,
           translation: { content },
         }: {
+          readonly reference: string
           readonly term: string
           readonly translation: { readonly content: string }
         }
-      ) => ({ ...terms, [term]: content }),
+      ) => ({ ...terms, [term]: content || reference }),
       {}
     )
   )


### PR DESCRIPTION
If no translation is provided in POEditor (case when you simply want to use the one exported by default), we should use the reference as a fallback for a given term.